### PR TITLE
Fix: add nr adapter to contracts to approve

### DIFF
--- a/examples/safeWallet/approveTokensForTrading.ts
+++ b/examples/safeWallet/approveTokensForTrading.ts
@@ -14,10 +14,13 @@ dotenvConfig({ path: resolve(__dirname, "../../.env") });
 // This example does all approvals necessary for trading
 // Approves:
 // USDC on the CTF Contract
+// USDC on the Neg Risk Adapter
 // USDC on the CTF Exchange Contract
 // USDC on the Neg Risk Exchange Contract
+
 // CTF Outcome Tokens on the CTF Exchange Contract
 // CTF Outcome Tokens on the Neg Risk Exchange Contract
+// CTF Outcome Tokens on the Neg Risk Adapter
 async function main() {
     console.log(`Starting...`);
     
@@ -33,6 +36,7 @@ async function main() {
     
     const usdcSpenders = [
         "0x4D97DCd97eC945f40cF65F87097ACe5EA0476045", // Conditional Tokens Framework
+        "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296", // Neg Risk Adapter
         "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E", // CTF Exchange
         "0xC5d563A36AE78145C45a50134d48A1215220f80a", // Neg Risk CTF Exchange
     ];
@@ -40,6 +44,7 @@ async function main() {
     const outcomeTokenSpenders = [
         "0x4bFb41d5B3570DeFd03C39a9A4D8dE6Bd8B8982E", // CTF Exchange
         "0xC5d563A36AE78145C45a50134d48A1215220f80a", // Neg Risk Exchange
+        "0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296", // Neg Risk Adapter
     ];
 
     const safeTxns: SafeTransaction[] = [];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds the Neg Risk Adapter to both USDC and outcome token approval lists in the safeWallet trading example.
> 
> - **Examples**:
>   - `examples/safeWallet/approveTokensForTrading.ts`
>     - Add Neg Risk Adapter (`0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296`) to `usdcSpenders` and `outcomeTokenSpenders`.
>     - Update approval comments to reflect new adapter coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3537d5533977f6d35c71c8ecfea98f501202b971. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->